### PR TITLE
do not hardcode python executable name and use sys.executable

### DIFF
--- a/tests/test_process_tests.py
+++ b/tests/test_process_tests.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import socket
 
 import pytest
@@ -13,7 +14,7 @@ TIMEOUT = int(os.getenv('TESTS_TIMEOUT', 60))
 
 
 def test_wait_for_strings():
-    with TestProcess('python', '-c', 'print("foobar")') as proc:
+    with TestProcess(sys.executable, '-c', 'print("foobar")') as proc:
         wait_for_strings(proc.read, TIMEOUT, 'foobar')
         with pytest.raises(AssertionError):
             with dump_on_error(proc.read):
@@ -22,7 +23,7 @@ def test_wait_for_strings():
 
 def test_filebuffer(tmp_path):
     with tmp_path.joinpath('stdout').open('wb') as fh:
-        with TestProcess('python', '-c', 'print("foobar")', stdout=fh) as proc:
+        with TestProcess(sys.executable, '-c', 'print("foobar")', stdout=fh) as proc:
             wait_for_strings(proc.read, TIMEOUT, 'foobar')
             with pytest.raises(AssertionError):
                 with dump_on_error(proc.read):
@@ -30,7 +31,7 @@ def test_filebuffer(tmp_path):
 
 
 def test_socket():
-    with TestProcess('python', '-mhttp.server', '0') as proc:
+    with TestProcess(sys.executable, '-mhttp.server', '0') as proc:
         with dump_on_error(proc.read, 'SERVER'):
             wait_for_strings(proc.read, TIMEOUT, 'Serving HTTP on')
             (port,) = re.match(r'Serving HTTP on .*? port (\d+) ', proc.read()).groups()


### PR DESCRIPTION
Python executabe name should not be hardcoded.
Use instead sys.executable().

Without that fix pytest is failing in my build env where I have only python3.
```console
+ /usr/bin/pytest -ra -m 'not network' --exit-0-if-no-units
============================= test session starts ==============================
platform linux -- Python 3.8.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/tkloczko/rpmbuild/BUILD/python-process-tests-3.0.0
configfile: pytest.ini
testpaths: tests
collected 3 items

tests/test_process_tests.py FFF                                          [100%]

=================================== FAILURES ===================================
____________________________ test_wait_for_strings _____________________________
tests/test_process_tests.py:16: in test_wait_for_strings
    with TestProcess('python', '-c', 'print("foobar")') as proc:
../../BUILDROOT/python-process-tests-3.0.0-2.fc35.x86_64/usr/lib/python3.8/site-packages/process_tests.py:129: in __init__
    self.proc = subprocess.Popen(args, stdout=stdout, **kwargs)
/usr/lib64/python3.8/subprocess.py:858: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
/usr/lib64/python3.8/subprocess.py:1720: in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
E   FileNotFoundError: [Errno 2] No such file or directory: 'python'
_______________________________ test_filebuffer ________________________________
tests/test_process_tests.py:25: in test_filebuffer
    with TestProcess('python', '-c', 'print("foobar")', stdout=fh) as proc:
../../BUILDROOT/python-process-tests-3.0.0-2.fc35.x86_64/usr/lib/python3.8/site-packages/process_tests.py:133: in __init__
    self.proc = subprocess.Popen(args, stdout=stdout, **kwargs)
/usr/lib64/python3.8/subprocess.py:858: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
/usr/lib64/python3.8/subprocess.py:1720: in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
E   FileNotFoundError: [Errno 2] No such file or directory: 'python'
_________________________________ test_socket __________________________________
tests/test_process_tests.py:33: in test_socket
    with TestProcess('python', '-mhttp.server', '0') as proc:
../../BUILDROOT/python-process-tests-3.0.0-2.fc35.x86_64/usr/lib/python3.8/site-packages/process_tests.py:129: in __init__
    self.proc = subprocess.Popen(args, stdout=stdout, **kwargs)
/usr/lib64/python3.8/subprocess.py:858: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
/usr/lib64/python3.8/subprocess.py:1720: in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
E   FileNotFoundError: [Errno 2] No such file or directory: 'python'
=========================== short test summary info ============================
FAILED tests/test_process_tests.py::test_wait_for_strings - FileNotFoundError...
FAILED tests/test_process_tests.py::test_filebuffer - FileNotFoundError: [Err...
FAILED tests/test_process_tests.py::test_socket - FileNotFoundError: [Errno 2...
============================== 3 failed in 0.19s ===============================
```
