### PR TITLE
Add optional ignore_case param to wait_for_strings

### DIFF
--- a/src/process_tests.py
+++ b/src/process_tests.py
@@ -223,7 +223,7 @@ class TestSocket(PipeBuffer if fcntl else ThreadedBuffer):
     close = __exit__
 
 
-def wait_for_strings(cb, seconds, *strings):
+def wait_for_strings(cb, seconds, *strings, ignore_case=False):
     """
     This checks that *string appear in cb(), IN THE GIVEN ORDER !
     """
@@ -232,7 +232,11 @@ def wait_for_strings(cb, seconds, *strings):
         buff = cb()
         check_strings = list(strings)
         check_strings.reverse()
+        if ignore_case:
+            check_strings = [string.casefold() for string in check_strings]
         for line in buff.splitlines():
+            if ignore_case:
+                line = line.casefold()
             if not check_strings:
                 break
             while check_strings and check_strings[-1] in line:


### PR DESCRIPTION
**Motivation:**

While trying to build [python-redis-lock](https://github.com/ionelmc/python-redis-lock) 
on NixOS with **redis-server version 7.2.5**
the tests kept failing at `wait_for_strings` assertion on the output of redis-server, because the redis-server was outputting:
`Ready to accept connections` 
instead of 
`ready to accept connections` (different string case)

```
# python-redis-lock: tests/conftest.py
    with TestProcess(
        'redis-server', '--port', '0', '--save', '', '--appendonly', 'yes', '--dir', tmp_path, '--unixsocket', redis_socket
    ) as redis_server:
        wait_for_strings(redis_server.read, 2, 'ready to accept connections')
```

I would also create a PR in parallel to this one, in python-redis-lock repository, to make use of the change proposed in this PR in case it got approved and released.